### PR TITLE
Add better and flexibel seed data: users, stories & likes.

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -25,13 +25,19 @@ $factory->define(App\Story::class, function (Faker\Generator $faker) {
         'title'     => $faker->sentence,
         'body'      => $faker->paragraph(20),
         'image_url' => 'https://unsplash.it/1024/1024?image=' . $faker->numberBetween(1, 1000),
-        'user_id'   => factory(App\User::class)->create()->id,
+        'user_id'   => function () {
+            return factory(App\User::class)->create()->id;
+        }
     ];
 });
 
 $factory->define(App\Like::class, function (Faker\Generator $faker) {
     return [
-        'user_id'  => factory(App\User::class)->create()->id,
-        'story_id' => factory(App\Story::class)->create()->id,
+        'user_id'  => function () {
+            return factory(App\User::class)->create()->id;
+        },
+        'story_id' => function () {
+            return factory(App\Story::class)->create()->id;
+        },
     ];
 });

--- a/database/seeds/LikesTableSeeder.php
+++ b/database/seeds/LikesTableSeeder.php
@@ -8,8 +8,18 @@ use Symfony\Component\Console\Helper\ProgressBar;
 class LikesTableSeeder extends Seeder
 {
 
+    /**
+     * The array holding the generated likes.
+     *
+     * @type Array
+     */
     protected $likes = [];
 
+    /**
+     * The amount of users in the database.
+     *
+     * @type Number
+     */
     protected $userCount = 0;
 
     /**
@@ -20,11 +30,27 @@ class LikesTableSeeder extends Seeder
     public function run()
     {
         DB::table('likes')->truncate();
+
+        $this->command->info('Seeding a random amount of likes per story from random users...');
+
         $this->likes = [];
         $this->userCount = App\User::count();
 
         App\Story::all()->each(function($story) {
-            $this->likes[] = $this->makeLike($story->id, rand(0, 20));
+            $amount = mt_rand(round($this->userCount * -0.1), round($this->userCount * 0.25));
+
+            if ($amount < 1) return;
+
+            $likes = $this->makeLikes($story->id, $amount);
+
+            if ($likes instanceof App\Like) {
+                $this->likes[] = $likes;
+                return;
+            }
+
+            foreach($likes as $like) {
+                $this->likes[] = $like;
+            }
         });
 
         foreach ($this->likes as $like) {
@@ -32,21 +58,35 @@ class LikesTableSeeder extends Seeder
         }
     }
 
-    public function seedLike(Like $like)
+    /**
+     * Attempt to seed the like in the database.
+     *
+     * @param  Like $like
+     * @return void
+     */
+    protected function seedLike(Like $like)
     {
         try {
             $like->save();
         } catch(QueryException $e) {
-            $like = $this->makeLike($like->story_id);
+            $like = $this->makeLikes($like->story_id);
             $this->seedLike($like);
         }
     }
 
-    protected function makeLike($story_id, $amount = 1)
+    /**
+     * Generate a like or multiple likes.
+     *
+     * @param  String $story_id
+     * @param  Integer $amount
+     *
+     * @return Illuminate\Database\Eloquent\Collection | App\Like
+     */
+    protected function makeLikes($story_id, $amount = 1)
     {
         return factory(App\Like::class, $amount)->make([
             'story_id' => $story_id,
-            'user_id'  => rand(0, $this->userCount),
+            'user_id'  => mt_rand(0, $this->userCount),
         ]);
     }
 }

--- a/database/seeds/LikesTableSeeder.php
+++ b/database/seeds/LikesTableSeeder.php
@@ -82,10 +82,10 @@ class LikesTableSeeder extends Seeder
      *
      * @return Illuminate\Database\Eloquent\Collection | App\Like
      */
-    protected function makeLikes($story_id, $amount = 1)
+    protected function makeLikes($storyId, $amount = 1)
     {
         return factory(App\Like::class, $amount)->make([
-            'story_id' => $story_id,
+            'story_id' => $storyId,
             'user_id'  => mt_rand(0, $this->userCount),
         ]);
     }

--- a/database/seeds/StoriesTableSeeder.php
+++ b/database/seeds/StoriesTableSeeder.php
@@ -12,8 +12,15 @@ class StoriesTableSeeder extends Seeder
     public function run()
     {
         DB::table('stories')->truncate();
+
+        $this->command->info('Seeding a random amount of stories for every user...');
+
         App\User::all()->each(function($user) {
-            factory(App\Story::class, rand(0, 5))->create([
+            $amount = mt_rand(-20, 10);
+
+            if ($amount < 0) return;
+
+            factory(App\Story::class, mt_rand(-15, 10))->create([
                 'user_id' => $user->id,
             ]);
         });

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -4,6 +4,14 @@ use Illuminate\Database\Seeder;
 
 class UsersTableSeeder extends Seeder
 {
+
+    /**
+     * Amount of users to generate.
+     *
+     * @type Number
+     */
+    protected $amount = 500;
+
     /**
      * Run the database seeds.
      *
@@ -12,6 +20,7 @@ class UsersTableSeeder extends Seeder
     public function run()
     {
         DB::table('users')->truncate();
-        factory(App\User::class, 25)->create();
+        $this->command->info('Seeding ' . $this->amount . ' users...');
+        factory(App\User::class, $this->amount)->create();
     }
 }


### PR DESCRIPTION
I've added more extensive seeders that allow you to get better dummy data.
Based on the amount of users you seed (500 by default) you get stories for some users & every stories get a random amount of likes from all random users. This can be 0 to 25% of the total amount of users.

I've added more weight to below 0 to replicate a platform where not every story get likes, the same goes for stories. There are more users that haven't written a story, just like on a real platform.
